### PR TITLE
Update placeholders to new syntax (+ collateral normalization).

### DIFF
--- a/shortcuts.yml
+++ b/shortcuts.yml
@@ -1,15 +1,11 @@
-# Documentation:
-# https://github.com/trovu/trovu.github.io/wiki/Advanced-settings-&-personal-shortcuts#personal-shortcuts
-
 examplekeyword 0: http://www.example.com/
-examplekeyword 1: http://www.example.com/?q={%query} 
+examplekeyword 1: http://www.example.com/?q={%query}
 examplekeyword 2:
-  url: http://www.example.com/?q={%query}&p={%puery}
+  url: http://www.example.com/?q=<query>&p=<puery>
   title: Custom shortcut
   description: My custom shortcut with the keyword examplekeyword and 2 arguments.
   tags:
   - example
-
 cups 0:
   url: http://localhost:631/
   title: cups
@@ -25,12 +21,12 @@ gdr 0:
   examples:
     gdr: Go to Google Drive home page
 gdr 1:
-  url: https://drive.google.com/#search/{%query}
+  url: https://drive.google.com/#search/<query>
   title: Google Drive Search
   tags:
-  - storage
   - cloud
   - documents
+  - storage
   examples:
     grades: Search for documents with keyword "grades" in your Google Drive
 go 0:
@@ -42,52 +38,52 @@ go 0:
   - programming
   - programming language
 go 1:
-  url: https://golang.org/pkg/{%pkg}/
+  url: https://golang.org/pkg/<pkg>/
   title: Go standard library
   tags:
-  - golang
   - go
-  - programming language
+  - golang
   - programming
+  - programming language
   examples:
     flag: Open documentation for Go standard library package flag
 gp 0:
   url: https://play.google.com/store
   title: Google Play
   tags:
-  - music
   - app
   - apps
-  - store
   - appstore
-  - movies
+  - book
   - books
   - devices
   - movie
-  - book
+  - movies
+  - music
+  - store
 gp 1:
-  url: https://play.google.com/store/search?q={%query}
+  url: https://play.google.com/store/search?q=<query>
   title: Google Play
   tags:
-  - music
   - app
   - apps
-  - store
   - appstore
-  - movies
+  - book
   - books
   - devices
   - movie
-  - book
+  - movies
+  - music
+  - store
   examples:
     chambermaid swing: search for "Chambermaid Swing" in the Google Play store
 gpdf 1:
-  url: https://www.google.com/search?hl={$language}&q={%query}+filetype:pdf&ie=utf-8
+  url: https://www.google.com/search?hl=<$language>&q=<query>+filetype:pdf&ie=utf-8
   title: Google.com filetype:pdf
   tags:
-  - web search
   - google
   - pdf
+  - web search
   examples:
     berlin: Google search for "berlin"
 gr 0:
@@ -95,16 +91,16 @@ gr 0:
   title: Goodreads
   tags:
   - books
-  - reading
   - literature
+  - reading
   - social network
 gr 1:
-  url: https://www.goodreads.com/search?utf8=%E2%9C%93&query={%query}
+  url: https://www.goodreads.com/search?utf8=%E2%9C%93&query=<query>
   title: Goodreads
   tags:
   - books
-  - reading
   - literature
+  - reading
   - social network
   examples:
     discworld: search for Discworld novels on Goodreads
@@ -115,22 +111,22 @@ hik 0:
   - cinema
   - movie
 kym 1:
-  url: http://knowyourmeme.com/search?q={%query}
+  url: http://knowyourmeme.com/search?q=<query>
   title: Know Your Meme
   tags:
   - fun
-  - meme
   - internet culture
+  - meme
   examples:
     x y is x: search for the "X Y is X" meme
 ls 1:
-  url: http://labenz.texttheater.de/suche.php?sb={%query}
+  url: http://labenz.texttheater.de/suche.php?sb=<query>
   title: Freut euch des Labenz! - Suche
 lt 0:
   url: http://labenz.texttheater.de
   title: Freut euch des Labenz!
 lt 1:
-  url: http://labenz.texttheater.de/{%Labenz}
+  url: http://labenz.texttheater.de/<Labenz>
   title: Freut euch des Labenz!
 mb 0:
   url: https://mastodon.social/bookmarks
@@ -139,10 +135,10 @@ mwo 0:
   url: http://www.mediawiki.org
   title: mediawiki.org
 mwo 1:
-  url: http://www.mediawiki.org/wiki/Special:Search?search={%query}&fulltext=Search
+  url: http://www.mediawiki.org/wiki/Special:Search?search=<query>&fulltext=Search
   title: Suche auf mediawiki.org
 ons 1:
-  url: http://labenz.texttheater.de/ons.php?sa={%suchausdruck}
+  url: http://labenz.texttheater.de/ons.php?sa=<suchausdruck>
   title: Labenz-Ortsnamensuche
 opac 0:
   url: https://opac-duesseldorf.itk-rheinland.de
@@ -151,31 +147,31 @@ pmb 0:
   url: http://pmb.let.rug.nl/explorer/phrase.php
   title: PMB Explorer, phrase query form
   tags:
-  - parallel meaning bank
   - corpus
   - linguistics
+  - parallel meaning bank
 pmb 1:
-  url: http://pmb.let.rug.nl/explorer/phrase.php?q={%phrasequery}
+  url: http://pmb.let.rug.nl/explorer/phrase.php?q=<phrasequery>
   title: PMB Explorer, phrase query
   tags:
-  - parallel meaning bank
   - corpus
   - linguistics
+  - parallel meaning bank
   examples:
     new york: search for "New York" in the Groningen Meaning Bank
     can|pos=NN: search for "can" tagged as a noun in the Groningen Meaning Bank
 pmbd 2:
-  url: https://pmb.let.rug.nl/explorer/explore.php?part={%part}&doc_id={%docid}&type=drs.xml&alignment_language=en
+  url: https://pmb.let.rug.nl/explorer/explore.php?part=<part>&doc_id=<docid>&type=drs.xml&alignment_language=en
   title: PMB Explorer, document ID
   tags:
-  - parallel meaning bank
   - corpus
   - linguistics
+  - parallel meaning bank
   examples:
     new york: search for "New York" in the Groningen Meaning Bank
     can|pos=NN: search for "can" tagged as a noun in the Groningen Meaning Bank
 py3 1:
-  url: https://docs.python.org/3/search.html?q={%query}
+  url: https://docs.python.org/3/search.html?q=<query>
   title: Python 3 documentation
   tags:
   - programming
@@ -189,7 +185,7 @@ sf 0:
   url: https://forum.solawi-duesseldorf.de/
   title: SoLaWi-Düsseldorf-Forum
 sf 1:
-  url: https://forum.solawi-duesseldorf.de/search?q={%query}
+  url: https://forum.solawi-duesseldorf.de/search?q=<query>
   title: SoLaWi-Düsseldorf-Forum
 rl 0:
   url: https://www.goodreads.com/review/list/7713465-kilian?order=d&shelf=to-read&sort=avg_rating
@@ -202,118 +198,118 @@ swipl 0:
   url: http://www.swi-prolog.org/pldoc/index.html
   title: SWI-Prolog documentation
   tags:
-  - manual
-  - prolog
-  - programming
-  - documentation
   - doc
+  - documentation
+  - manual
+  - programming
+  - prolog
 swipl 1:
-  url: http://www.swi-prolog.org/pldoc/search?for={%query}&in=all&match=summary
+  url: http://www.swi-prolog.org/pldoc/search?for=<query>&in=all&match=summary
   title: SWi-Prolog documentation
   tags:
+  - doc
+  - documentation
+  - manual
   - programming
   - prolog
-  - documentation
-  - doc
-  - manual
   examples:
     append: Search SWI-Prolog site for documentation on appending
 tat 0:
   url: https://tatoeba.org
   title: Tatoeba
   tags:
-  - language
   - dictionary
-  - phrases
-  - phrasebook
+  - language
   - languages
+  - phrasebook
+  - phrases
 tat 1:
-  url: http://tatoeba.org/eng/sentences/search?query={%query}
+  url: http://tatoeba.org/eng/sentences/search?query=<query>
   title: Tatoeba
   tags:
-  - langugage
-  - phrases
-  - phrasebook
   - dictionary
   - languages
+  - langugage
+  - phrasebook
+  - phrases
   examples:
     not at all: search for translation of the phrase "not at all"
 tn* 1:
-  url: https://tweetnest.texttheater.net/search?q=%2A{%query}%2A
+  url: https://tweetnest.texttheater.net/search?q=%2A<query>%2A
   title: Tweets by @texttheater
 tn 0:
   url: https://tweetnest.texttheater.net
   title: Texttheater Tweet Nest
   tags:
-  - tweets
-  - tweet
-  - twitter
-  - self
   - ego
+  - self
+  - tweet
+  - tweets
+  - twitter
 tn 1:
-  url: https://tweetnest.texttheater.net/search?q={%query}
+  url: https://tweetnest.texttheater.net/search?q=<query>
   title: Tweets by @texttheater
 tnr 0:
   url: https://texttheater.net/tnr/
   title: Random Tweets by @texttheater
 tttt 1:
-  url: https://duckduckgo.com/?q={%query}+site%3Atexttheater.net
+  url: https://duckduckgo.com/?q=<query>+site%3Atexttheater.net
   title: DuckDuckGo-Suche im Texttheater
 ud 1:
-  url: http://www.urbandictionary.com/define.php?term={%query}
+  url: http://www.urbandictionary.com/define.php?term=<query>
   title: Urban Dictionary
   tags:
   - dictionary
-  - slang
   - english
+  - slang
   examples:
     wheelbo: Look up "wheelbo" in the Urban Dictionary
 ulb 1:
-  url: https://katalog.ulb.hhu.de/Search/Results?lng=de&type=AllFields&lookfor={%query}
+  url: https://katalog.ulb.hhu.de/Search/Results?lng=de&type=AllFields&lookfor=<query>
   title: Universitäts- und Landesbibliothek Düsseldorf, Katalog
 vf 0:
   url: https://forum.neutsch.org/index.php?action=unread;all;start=0
   title: GSV-Forum
 vf 1:
-  url: https://forum.neutsch.org/index.php?action=search2;search={%query}
+  url: https://forum.neutsch.org/index.php?action=search2;search=<query>
   title: Suche im GSV-Forum
 vv 0:
   url: https://neutsch.org/Starke_Verben
   title: Starke Verben im GSV-Wiki
 vv 1:
-  url: https://neutsch.org/Starke_Verben/{%buchstabe}
+  url: https://neutsch.org/Starke_Verben/<buchstabe>
   title: Starke Verben im GSV-Wiki
 vw 0:
   url: https://neutsch.org
   title: GSV-Wiki
 vw 1:
-  url: https://neutsch.org/index.php?title=Spezial%3ASuche&search={%query}
+  url: https://neutsch.org/index.php?title=Spezial%3ASuche&search=<query>
   title: Artikel oder Suche im GSV-Wiki
 vws 1:
-  url: https://neutsch.org/index.php?title={%title}&action=edit
+  url: https://neutsch.org/index.php?title=<title>&action=edit
   title: GSV-Wiki, schreiben
 wl 0:
   url: https://www.imdb.com/user/ur38214461/watchlist?sort=user_rating%2Cdesc&view=detail
   title: IMDb Watchlist
   tags:
-  - movie
   - film
-  - watchlist
+  - movie
   - watch
+  - watchlist
 wordnet 0:
   url: http://wordnetweb.princeton.edu/perl/webwn
   title: WordNet Search
 wordnet 1:
-  url: http://wordnetweb.princeton.edu/perl/webwn?s={%word_form}&o2=&o0=1&o8=1&o1=1&o7=&o5=&o9=&o6=1&o3=&o4=&h=000000000000000
+  url: http://wordnetweb.princeton.edu/perl/webwn?s=<word_form>&o2=&o0=1&o8=1&o1=1&o7=&o5=&o9=&o6=1&o3=&o4=&h=000000000000000
   title: WordNet Search, show sense keys
   tags:
-  - linguistics
-  - english
   - computational linguistics
-  - word
-  - words
+  - dictionary
+  - english
+  - linguistics
   - sense
   - senses
-  - dictionary
+  - word
+  - words
   examples:
     complicated: look up senses of "complicated" in WordNet


### PR DESCRIPTION
Placeholder syntax changed from `{%query}` to `<query>`.

Read more: https://trovu.net/docs/shortcuts/url/